### PR TITLE
Auto thread creation on specified channels and roles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,8 @@ target/
 
 **/logs/**
 ai
+
+#venv
+bin
+lib64
+pyvenv.cfg

--- a/cogs/_config.py
+++ b/cogs/_config.py
@@ -55,7 +55,7 @@ auto_thread_channels = [
     976770662205104150 # free-stuff channel
 ]
 auto_thread_roles = [
-    1190380868284457091 # free-stuff notif role
+    956006107564879873 # free-stuff notif role
 ]
 managing_roles = [956006107564879880, 956006107577454603]
 

--- a/cogs/_config.py
+++ b/cogs/_config.py
@@ -50,6 +50,10 @@ channel_ids = [
     1099381748011380909,  # unknown??
 ]
 
+# Automatic thread creation
+auto_thread_channels = [1190380815700467795]
+auto_thread_roles = [1190380868284457091] #To trigger thread creation
+
 managing_roles = [956006107564879880, 956006107577454603]
 
 rss_chan_ids = [int(i) for i in RSS_CHANNELS.split(",")]

--- a/cogs/_config.py
+++ b/cogs/_config.py
@@ -52,7 +52,7 @@ channel_ids = [
 
 # Automatic thread creation
 auto_thread_channels = [1190380815700467795]
-auto_thread_roles = [1190380868284457091] #To trigger thread creation
+auto_thread_roles = [1190380868284457091]  # To trigger thread creation
 
 managing_roles = [956006107564879880, 956006107577454603]
 

--- a/cogs/_config.py
+++ b/cogs/_config.py
@@ -51,9 +51,12 @@ channel_ids = [
 ]
 
 # Automatic thread creation
-auto_thread_channels = [1190380815700467795]
-auto_thread_roles = [1190380868284457091]  # To trigger thread creation
-
+auto_thread_channels = [
+    976770662205104150 # free-stuff channel
+]
+auto_thread_roles = [
+    1190380868284457091 # free-stuff notif role
+]
 managing_roles = [956006107564879880, 956006107577454603]
 
 rss_chan_ids = [int(i) for i in RSS_CHANNELS.split(",")]

--- a/cogs/events.py
+++ b/cogs/events.py
@@ -71,8 +71,7 @@ class EventHandling(commands.Cog):
         ):
             await message.create_thread(
                 name="Auto-Thread - Please keep discussions in here!",
-                reason="Auto thread created by FMHY Bot",
-                auto_archive_duration=60)
+                reason="Auto thread created by FMHY Bot")
 
         if message.author.bot:
             return

--- a/cogs/events.py
+++ b/cogs/events.py
@@ -5,7 +5,7 @@ from datetime import datetime
 import discord
 from discord.ext import commands, tasks
 
-from cogs._config import channel_ids, managing_roles, url_regex
+from cogs._config import channel_ids, managing_roles, url_regex, auto_thread_channels, auto_thread_roles
 from cogs._helpers import cembed
 from main import Bot
 
@@ -66,6 +66,14 @@ class EventHandling(commands.Cog):
 
     @commands.Cog.listener()
     async def on_message(self, message: discord.Message):
+        if message.channel.id in auto_thread_channels and any(
+            str(role) in message.content for role in auto_thread_roles
+        ):
+            await message.create_thread(
+                name="Auto-Thread - Please keep discussions in here!",
+                reason="Auto thread created by FMHY Bot",
+                auto_archive_duration=60)
+
         if message.author.bot:
             return
         if message.channel.id in channel_ids:
@@ -91,7 +99,8 @@ class EventHandling(commands.Cog):
                 # Partial duplicates
                 elif len(message_links) > 1 and len(duplicate_links) >= 1:
                     non_duplicate_links_string = "\n".join(
-                        [f"{protocol}://{link}" for protocol, link in non_duplicate_links]
+                        [f"{protocol}://{link}" for protocol,
+                            link in non_duplicate_links]
                     )
                     non_duplicate_links_embed = cembed(
                         title="__Non-Duplicate Links:__",
@@ -119,10 +128,13 @@ class EventHandling(commands.Cog):
             if emoji == self.bookmark_emoji:
                 attachments = msg.attachments
                 embed = discord.Embed(color=0x2B2D31, timestamp=datetime.now())
-                embed.set_author(name=msg.author.name, icon_url=msg.author.display_avatar)
+                embed.set_author(name=msg.author.name,
+                                 icon_url=msg.author.display_avatar)
                 embed.description = msg.content[:4096]
-                embed.add_field(name="Jump", value=f"[Go to Message!]({msg.jump_url})")
-                embed.set_footer(text=f"Guild: {channel.guild.name} | Channel: #{channel.name}")
+                embed.add_field(
+                    name="Jump", value=f"[Go to Message!]({msg.jump_url})")
+                embed.set_footer(
+                    text=f"Guild: {channel.guild.name} | Channel: #{channel.name}")
                 attach = ""
                 if attachments:
                     img_added = False

--- a/main.py
+++ b/main.py
@@ -47,7 +47,8 @@ class Bot(commands.Bot):
                     self.logger.info(f"Loaded - {extension}")
                 except Exception as e:
                     exception = f"{type(e).__name__}: {e}"
-                    self.logger.exception(f"Failed to load extension {extension}. - {exception}")
+                    self.logger.exception(
+                        f"Failed to load extension {extension}. - {exception}")
                     traceback.print_exc()
 
         elapsed = time.perf_counter() - s


### PR DESCRIPTION
Added functionality to listen for messages that contain an specific role in an specified channel to create threads on said message.

I added venv stuff to the .gitignore by accident but shouldn't hurt anything.

And also autopep8 formatted some files but again should be fine.